### PR TITLE
Fix: Missing CSRF in forgot password page

### DIFF
--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -6,7 +6,13 @@
         <h1 class="auth-title">Forgot Password</h1>
         <p class="auth-subtitle mb-5">Input your email and we will send you reset password link.</p>
 
+        @if (session('status'))
+        <div class="mb-4 font-medium text-sm text-green-600">
+            {{ session('status') }}
+        </div>
+        @endif
         <form action="{{ route('password.email') }}" method="POST">
+            @csrf
             <div class="form-group position-relative has-icon-left mb-4">
                 <input type="email" class="form-control form-control-xl" placeholder="Email" value="{{ old('email') }}" name="email">
                 <div class="form-control-icon">

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -1,36 +1,38 @@
 <x-guest-layout>
-    <x-jet-authentication-card>
-        <x-slot name="logo">
-            <x-jet-authentication-card-logo />
-        </x-slot>
-
-        <x-jet-validation-errors class="mb-4" />
-
+    <div id="auth-left">
+        <div class="auth-logo">
+            <a href="index.html"><img src="{{ asset('/images/logo/logo.png') }}" alt="Logo"></a>
+        </div>
+        <h1 class="auth-title">Reset Password</h1>
+        <p class="auth-subtitle mb-5">Input your password to</p>
+        @if ($errors->any())
+        <div class="alert alert-danger">
+            {{ $errors->first() }}
+        </div>
+        @endif
         <form method="POST" action="{{ route('password.update') }}">
             @csrf
-
+    
             <input type="hidden" name="token" value="{{ $request->route('token') }}">
-
-            <div class="block">
-                <x-jet-label for="email" value="{{ __('Email') }}" />
-                <x-jet-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email', $request->email)" required autofocus />
+            <div class="form-group position-relative has-icon-left mb-4">
+                <input type="email" class="form-control form-control-xl" placeholder="Email" value="{{ old('email', $request->email) }}" name="email">
+                <div class="form-control-icon">
+                    <i class="bi bi-envelope"></i>
+                </div>
             </div>
-
-            <div class="mt-4">
-                <x-jet-label for="password" value="{{ __('Password') }}" />
-                <x-jet-input id="password" class="block mt-1 w-full" type="password" name="password" required autocomplete="new-password" />
+            <div class="form-group position-relative has-icon-left mb-4">
+                <input type="password" class="form-control form-control-xl" placeholder="Password" value="{{ old('password') }}" name="password">
+                <div class="form-control-icon">
+                    <i class="bi bi-shield-lock"></i>
+                </div>
             </div>
-
-            <div class="mt-4">
-                <x-jet-label for="password_confirmation" value="{{ __('Confirm Password') }}" />
-                <x-jet-input id="password_confirmation" class="block mt-1 w-full" type="password" name="password_confirmation" required autocomplete="new-password" />
+            <div class="form-group position-relative has-icon-left mb-4">
+                <input type="password" class="form-control form-control-xl" placeholder="Confirm Password" value="{{ old('password_confirmation') }}" name="password_confirmation">
+                <div class="form-control-icon">
+                    <i class="bi bi-shield-lock"></i>
+                </div>
             </div>
-
-            <div class="flex items-center justify-end mt-4">
-                <x-jet-button>
-                    {{ __('Reset Password') }}
-                </x-jet-button>
-            </div>
+            <button class="btn btn-primary btn-block btn-lg shadow-lg mt-5">Reset Password</button>
         </form>
-    </x-jet-authentication-card>
+    </div>
 </x-guest-layout>


### PR DESCRIPTION
When we try to submit email in forgot password page, the page will appear with 419 code that indicate the csrf token is missing
![Screenshot_20230528_162743](https://github.com/zuramai/laravel-mazer/assets/51155424/5a6426de-079d-4b11-aefc-2ffbc88324aa)
And the problem is because `@csrf` is missing

I've also improve the reset-password page a bit by using a mazer style instead of the default jetstream style